### PR TITLE
Limit Posts for Authors.

### DIFF
--- a/core/client/models/post.js
+++ b/core/client/models/post.js
@@ -18,6 +18,7 @@ var Post = DS.Model.extend(NProgressSaveMixin, ValidationEngine, {
     meta_title: DS.attr('string'),
     meta_description: DS.attr('string'),
     author: DS.belongsTo('user',  { async: true }),
+    author_id: DS.attr('number'),
     updated_at: DS.attr('moment-date'),
     published_at: DS.attr('moment-date'),
     published_by: DS.belongsTo('user', { async: true }),

--- a/core/client/routes/posts.js
+++ b/core/client/routes/posts.js
@@ -21,7 +21,11 @@ var PostsRoute = Ember.Route.extend(SimpleAuth.AuthenticatedRouteMixin, Shortcut
             }
             // using `.filter` allows the template to auto-update when new models are pulled in from the server.
             // we just need to 'return true' to allow all models by default.
-            return self.store.filter('post', paginationSettings, function () {
+            return self.store.filter('post', paginationSettings, function (post) {
+                if (user.get('isAuthor')) {
+                    return user.get('id') === post.get('author_id');
+                }
+
                 return true;
             });
         });

--- a/core/client/routes/posts/post.js
+++ b/core/client/routes/posts/post.js
@@ -35,6 +35,11 @@ var PostsPostRoute = Ember.Route.extend(SimpleAuth.AuthenticatedRouteMixin, load
             return self.store.find('post', paginationSettings).then(function (records) {
                 var post = records.get('firstObject');
 
+                if (user.get('isAuthor') && user.get('id') !== post.get('author_id')) {
+                    // do not show the post if they are an author but not this posts author
+                    post = null;
+                }
+
                 if (post) {
                     return post;
                 }

--- a/core/client/serializers/post.js
+++ b/core/client/serializers/post.js
@@ -6,6 +6,15 @@ var PostSerializer = ApplicationSerializer.extend(DS.EmbeddedRecordsMixin, {
         tags: { embedded: 'always' }
     },
 
+    normalize: function (type, hash) {
+        // this is to enable us to still access the raw author_id
+        // without requiring an extra get request (since it is an
+        // async relationship).
+        hash.author_id = hash.author;
+
+        return this._super(type, hash);
+    },
+
     extractSingle: function (store, primaryType, payload) {
         var root = this.keyForAttribute(primaryType.typeKey),
             pluralizedRoot = Ember.String.pluralize(primaryType.typeKey);


### PR DESCRIPTION
- Ensures that posts listing only shows posts that the current user
  authored, if they only have the Author role.
- Do not transition into the posts.post route if the current user is
  not the author (but has the Author role). This is needed because
  the API server will always return the post (regardless of the current
  user).
