### PR TITLE
Moved serve-favicon onto the proxy seam

### DIFF
--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -64,7 +64,6 @@ module.exports = {
                     '^ghost/core/core/frontend/web/middleware/frontend-caching\\.js$',
                     '^ghost/core/core/frontend/web/middleware/handle-image-sizes\\.js$',
                     '^ghost/core/core/frontend/web/routers/link-redirects\\.js$',
-                    '^ghost/core/core/frontend/web/routers/serve-favicon\\.js$',
                     '^ghost/core/core/frontend/apps/private-blogging/lib/router\\.js$',
 
                     // Leaks that bypass the proxy (fix first).

--- a/ghost/core/core/frontend/web/routers/serve-favicon.js
+++ b/ghost/core/core/frontend/web/routers/serve-favicon.js
@@ -2,7 +2,7 @@ const fs = require('fs-extra');
 const path = require('path');
 const crypto = require('crypto');
 const config = require('../../../shared/config');
-const {blogIcon} = require('../../../server/lib/image');
+const {blogIcon} = require('../../services/proxy');
 const urlUtils = require('../../../shared/url-utils');
 const settingsCache = require('../../../shared/settings-cache');
 


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost/pull/28420

First ratchet click of the frontend decoupling series — deliberately the smallest possible one, to pipe-clean the whole process (fork PR → CI → integration branch → upstream wave).

serve-favicon's one remaining `core/server` require is `blogIcon`, which the proxy already exports; its storage require was removed in TryGhost/Ghost#28745. Requiring it through the sanctioned seam instead lets the file come off the boundary allowlist in `.dependency-cruiser.cjs`.

Verified: `pnpm lint:boundaries` green with the allowlist entry deleted; full frontend unit suite green (1937 tests).