### PR TITLE
Moved the unsubscribe controller onto the proxy seam

### DIFF
--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -67,7 +67,6 @@ module.exports = {
                     '^ghost/core/core/frontend/apps/private-blogging/lib/router\\.js$',
 
                     // Leaks that bypass the proxy (fix first).
-                    '^ghost/core/core/frontend/services/routing/controllers/unsubscribe\\.js$', // services/members + settings-helpers
                     '^ghost/core/core/frontend/services/routing/router-manager\\.js$', // server/lib/common/events bus
                     '^ghost/core/core/frontend/services/sitemap/site-map-manager\\.js$' // server/lib/common/events bus
                 ]

--- a/ghost/core/core/frontend/services/proxy.js
+++ b/ghost/core/core/frontend/services/proxy.js
@@ -62,7 +62,16 @@ module.exports = {
 
     // Settings helpers for calculated settings
     settingsHelpers: {
-        isWebAnalyticsEnabled: settingsHelpers.isWebAnalyticsEnabled.bind(settingsHelpers)
+        isWebAnalyticsEnabled: settingsHelpers.isWebAnalyticsEnabled.bind(settingsHelpers),
+        // Delegates at call time (not bound at load) so tests that stub the
+        // method on the settings-helpers service are still seen through here.
+        getMembersValidationKey: (...args) => settingsHelpers.getMembersValidationKey(...args)
+    },
+
+    // Member actions needed by the frontend's unsubscribe route. Lazy so that
+    // loading the proxy does not pull the members service in ahead of boot.
+    get members() {
+        return require('../../server/services/members');
     },
 
     // TODO: Expose less of the API to make this safe

--- a/ghost/core/core/frontend/services/routing/controllers/unsubscribe.js
+++ b/ghost/core/core/frontend/services/routing/controllers/unsubscribe.js
@@ -1,9 +1,8 @@
 const debug = require('@tryghost/debug')('services:routing:controllers:unsubscribe');
 const url = require('url');
-const members = require('../../../../server/services/members');
+const {members, settingsHelpers} = require('../../proxy');
 const urlUtils = require('../../../../shared/url-utils');
 const logging = require('@tryghost/logging');
-const settingsHelpers = require('../../../../server/services/settings-helpers');
 const crypto = require('crypto');
 
 module.exports = async function unsubscribeController(req, res) {


### PR DESCRIPTION
ref TryGhost/Ghost#28420 · Frontend Contract M2, ratchet click 1 of 3

unsubscribe.js was reaching into `core/server` for the members service and settings-helpers. Both now come through the sanctioned proxy seam: a lazy `members` export (so loading the proxy doesn't pull the members service ahead of boot) and `getMembersValidationKey` (call-time delegation so service-level test stubs are still seen — the proxy-DI spike's stand-in rule, encountered in the wild). Allowlist entry deleted.

Verified: `pnpm lint:boundaries` green; frontend unit suite green (1937); `test/e2e-frontend/members.test.js` green (68, includes all unsubscribe routes).