### PR TITLE
Moved router events onto a frontend-internal emitter

### DIFF
--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -67,7 +67,6 @@ module.exports = {
                     '^ghost/core/core/frontend/apps/private-blogging/lib/router\\.js$',
 
                     // Leaks that bypass the proxy (fix first).
-                    '^ghost/core/core/frontend/services/routing/router-manager\\.js$', // server/lib/common/events bus
                     '^ghost/core/core/frontend/services/sitemap/site-map-manager\\.js$' // server/lib/common/events bus
                 ]
             },

--- a/ghost/core/core/frontend/services/routing/events.js
+++ b/ghost/core/core/frontend/services/routing/events.js
@@ -1,0 +1,12 @@
+const EventEmitter = require('events').EventEmitter;
+
+/**
+ * Frontend-internal routing events.
+ *
+ * Carries `router.created` and `routers.reset`, which are emitted by the
+ * router manager and consumed only inside the frontend (the sitemap keeps
+ * its route entries in sync from them). They used to ride the server's
+ * shared event bus purely for historical reasons — nothing server-side
+ * listens to them.
+ */
+module.exports = new EventEmitter();

--- a/ghost/core/core/frontend/services/routing/router-manager.js
+++ b/ghost/core/core/frontend/services/routing/router-manager.js
@@ -9,8 +9,8 @@ const ParentRouter = require('./parent-router');
 const EmailRouter = require('./email-router');
 const UnsubscribeRouter = require('./unsubscribe-router');
 
-// This emits its own routing events
-const events = require('../../../server/lib/common/events');
+// Frontend-internal routing events (router.created / routers.reset)
+const routingEvents = require('./events');
 
 class RouterManager {
     constructor({registry}) {
@@ -31,9 +31,7 @@ class RouterManager {
     }
 
     routerCreated(router) {
-        // NOTE: this event should be become an "internal frontend even"
-        //       and should not be consumed by the modules outside the frontend
-        events.emit('router.created', router);
+        routingEvents.emit('router.created', router);
 
         // CASE: there are router types which do not generate resource urls
         //       e.g. static route router, in this case we don't want ot notify the URL service
@@ -68,9 +66,7 @@ class RouterManager {
         this.registry.resetAllRouters();
         this.registry.resetAllRoutes();
 
-        // NOTE: this event could become an "internal frontend" in the future, it's used has been kept to prevent
-        //       from tying up this module with sitemaps
-        events.emit('routers.reset');
+        routingEvents.emit('routers.reset');
 
         this.siteRouter = new ParentRouter('SiteRouter');
         this.registry.setRouter('siteRouter', this.siteRouter);

--- a/ghost/core/core/frontend/services/sitemap/site-map-manager.js
+++ b/ghost/core/core/frontend/services/sitemap/site-map-manager.js
@@ -8,7 +8,9 @@ const PostsMapGenerator = require('./post-map-generator');
 const UsersMapGenerator = require('./user-map-generator');
 const TagsMapGenerator = require('./tags-map-generator');
 
-// This uses events from the routing service and the URL service
+// Frontend-internal routing events (router.created / routers.reset)
+const routingEvents = require('../routing/events');
+// Server events: url.added / url.removed from the URL service, site.changed
 const events = require('../../../server/lib/common/events');
 
 // What the sitemap XML reads off each resource, beyond the columns URL
@@ -53,7 +55,7 @@ class SiteMapManager {
         // every rebuild can replay them after resetting the generators.
         this._routerEntries = [];
 
-        events.on('router.created', (router) => {
+        routingEvents.on('router.created', (router) => {
             if (router.name !== 'StaticRoutesRouter' && router.name !== 'CollectionRouter') {
                 return;
             }
@@ -96,7 +98,7 @@ class SiteMapManager {
             this[obj.resource.config.type].removeUrl(obj.url.absolute, obj.resource.data);
         });
 
-        events.on('routers.reset', () => {
+        routingEvents.on('routers.reset', () => {
             this.pages && this.pages.reset();
             this.posts && this.posts.reset();
             this.users && this.users.reset();

--- a/ghost/core/test/unit/frontend/services/sitemap/manager.test.js
+++ b/ghost/core/test/unit/frontend/services/sitemap/manager.test.js
@@ -7,6 +7,7 @@ const DomainEvents = require('@tryghost/domain-events');
 const {URLResourceUpdatedEvent} = require('../../../../../core/shared/events');
 
 const events = require('../../../../../core/server/lib/common/events');
+const routingEvents = require('../../../../../core/frontend/services/routing/events');
 const urlUtils = require('../../../../../core/shared/url-utils');
 
 const SiteMapManager = require('../../../../../core/frontend/services/sitemap/site-map-manager');
@@ -51,6 +52,10 @@ describe('Unit: sitemap/manager', function () {
         // @NOTE: the pattern of faking event call is not great, we should be
         //        ideally tasting on real events instead of faking them
         sinon.stub(events, 'on').callsFake(function (eventName, callback) {
+            eventsToRemember[eventName] = callback;
+        });
+        // router.created / routers.reset are frontend-internal routing events
+        sinon.stub(routingEvents, 'on').callsFake(function (eventName, callback) {
             eventsToRemember[eventName] = callback;
         });
 


### PR DESCRIPTION
ref TryGhost/Ghost#28420 · Frontend Contract M2, ratchet click 2 of 3

`router.created`/`routers.reset` are emitted by router-manager and consumed only by the sitemap — verified: no server-side listeners exist. They now ride a routing-local emitter (`services/routing/events.js`), fulfilling the long-standing in-code NOTEs, and router-manager comes off the boundary allowlist. The sitemap keeps the server bus only for `url.added`/`url.removed`/`site.changed` (next PR).

Verified: `pnpm lint:boundaries` green; frontend unit suite green (1937, incl. updated sitemap manager test); `test/integration/sitemap-parity.test.js` green (real boot flow through the new emitter).