### PR TITLE
Moved sitemap server events onto the proxy seam

### DIFF
--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -64,10 +64,7 @@ module.exports = {
                     '^ghost/core/core/frontend/web/middleware/frontend-caching\\.js$',
                     '^ghost/core/core/frontend/web/middleware/handle-image-sizes\\.js$',
                     '^ghost/core/core/frontend/web/routers/link-redirects\\.js$',
-                    '^ghost/core/core/frontend/apps/private-blogging/lib/router\\.js$',
-
-                    // Leaks that bypass the proxy (fix first).
-                    '^ghost/core/core/frontend/services/sitemap/site-map-manager\\.js$' // server/lib/common/events bus
+                    '^ghost/core/core/frontend/apps/private-blogging/lib/router\\.js$'
                 ]
             },
             to: {path: '^ghost/core/core/server/'}

--- a/ghost/core/core/frontend/services/proxy.js
+++ b/ghost/core/core/frontend/services/proxy.js
@@ -4,7 +4,14 @@ const config = require('../../shared/config');
 const settingsHelpers = require('../../server/services/settings-helpers');
 const storageUtils = require('../../server/adapters/storage/utils');
 const internalKeys = require('../../server/services/internal-keys').default;
+const serverEventBus = require('../../server/lib/common/events');
+const errors = require('@tryghost/errors');
 const logging = require('@tryghost/logging');
+
+// The only server events the frontend may subscribe to. A narrow surface on
+// purpose: the shared bus's own header discourages widening cross-layer
+// coupling, so new event names here need the same scrutiny as new exports.
+const FRONTEND_SUBSCRIBABLE_EVENTS = ['site.changed', 'url.added', 'url.removed'];
 
 // Require from the handlebars framework
 const {SafeString} = require('./handlebars');
@@ -76,6 +83,19 @@ module.exports = {
 
     // TODO: Expose less of the API to make this safe
     api: require('../../server/api').endpoints,
+
+    // Narrow subscription surface for server events the frontend reacts to
+    serverEvents: {
+        on(eventName, listener) {
+            if (!FRONTEND_SUBSCRIBABLE_EVENTS.includes(eventName)) {
+                throw new errors.IncorrectUsageError({
+                    message: `The frontend may not subscribe to the server event "${eventName}"`,
+                    context: `Allowed events: ${FRONTEND_SUBSCRIBABLE_EVENTS.join(', ')}`
+                });
+            }
+            serverEventBus.on(eventName, listener);
+        }
+    },
 
     // Labs utils for enabling/disabling helpers
     labs: require('../../shared/labs'),

--- a/ghost/core/core/frontend/services/sitemap/site-map-manager.js
+++ b/ghost/core/core/frontend/services/sitemap/site-map-manager.js
@@ -10,8 +10,6 @@ const TagsMapGenerator = require('./tags-map-generator');
 
 // Frontend-internal routing events (router.created / routers.reset)
 const routingEvents = require('../routing/events');
-// Server events: url.added / url.removed from the URL service, site.changed
-const events = require('../../../server/lib/common/events');
 
 // What the sitemap XML reads off each resource, beyond the columns URL
 // computation needs: lastmod dates, image nodes, and the canonical_url skip
@@ -43,6 +41,12 @@ class SiteMapManager {
         // url service loads at require time and loading it when this module
         // loads would change boot order.
         this._urlService = options.urlService || null;
+
+        // Server events arrive through the proxy's narrow subscription
+        // surface (site.changed, url.added, url.removed). Injectable for
+        // tests; resolved at construction (not module load) for the same
+        // boot-order reason as the url service above.
+        this._serverEvents = options.serverEvents || require('../proxy').serverEvents;
 
         // Index state for the build path. _indexEpoch increments on every
         // invalidation signal; a build compares the epoch it started with so
@@ -78,7 +82,7 @@ class SiteMapManager {
         // current after the initial build, exactly as before this change —
         // deploying is a no-op until the lazy flip. Pure lazy fires no
         // events, so there the index empties and the next read rebuilds.
-        events.on('site.changed', () => {
+        this._serverEvents.on('site.changed', () => {
             if (this._getUrlService().isLazy()) {
                 this._invalidateIndex();
             }
@@ -90,11 +94,11 @@ class SiteMapManager {
             this[event.data.resourceType].updateURL(event.data);
         });
 
-        events.on('url.added', (obj) => {
+        this._serverEvents.on('url.added', (obj) => {
             this[obj.resource.config.type].addUrl(obj.url.absolute, obj.resource.data);
         });
 
-        events.on('url.removed', (obj) => {
+        this._serverEvents.on('url.removed', (obj) => {
             this[obj.resource.config.type].removeUrl(obj.url.absolute, obj.resource.data);
         });
 

--- a/ghost/core/test/unit/frontend/services/sitemap/manager.test.js
+++ b/ghost/core/test/unit/frontend/services/sitemap/manager.test.js
@@ -6,7 +6,6 @@ const {assertExists} = require('../../../../utils/assertions');
 const DomainEvents = require('@tryghost/domain-events');
 const {URLResourceUpdatedEvent} = require('../../../../../core/shared/events');
 
-const events = require('../../../../../core/server/lib/common/events');
 const routingEvents = require('../../../../../core/frontend/services/routing/events');
 const urlUtils = require('../../../../../core/shared/url-utils');
 
@@ -42,6 +41,13 @@ describe('Unit: sitemap/manager', function () {
                 isLazy: () => false,
                 getRoutableResources: async () => [],
                 getUrlForResource: () => '/x/'
+            },
+            // Server events come through the proxy's narrow surface in
+            // production; injected here like the url service
+            serverEvents: {
+                on: (eventName, callback) => {
+                    eventsToRemember[eventName] = callback;
+                }
             }
         });
     };
@@ -51,9 +57,6 @@ describe('Unit: sitemap/manager', function () {
 
         // @NOTE: the pattern of faking event call is not great, we should be
         //        ideally tasting on real events instead of faking them
-        sinon.stub(events, 'on').callsFake(function (eventName, callback) {
-            eventsToRemember[eventName] = callback;
-        });
         // router.created / routers.reset are frontend-internal routing events
         sinon.stub(routingEvents, 'on').callsFake(function (eventName, callback) {
             eventsToRemember[eventName] = callback;
@@ -145,7 +148,12 @@ describe('Unit: sitemap/manager', function () {
                     pages: new PageGenerator(),
                     tags: new TagGenerator(),
                     authors: new UserGenerator(),
-                    urlService
+                    urlService,
+                    serverEvents: {
+                        on: (eventName, callback) => {
+                            eventsToRemember[eventName] = callback;
+                        }
+                    }
                 });
             }
 


### PR DESCRIPTION
ref TryGhost/Ghost#28420 · Frontend Contract M2, ratchet click 3 of 3. Replaces #32, which GitHub auto-closed when its stacked base branch was deleted on #31's merge.

The sitemap's three genuine server→frontend notifications (`url.added`, `url.removed`, `site.changed`) now arrive through a narrow `serverEvents` subscription surface on the proxy (allowlisted event names only, throws otherwise) instead of a direct require of the shared bus. Resolved at construction to preserve boot order; injectable for tests. Sitemap comes off the boundary allowlist — the frontend's "fix first" leak list is now **empty**.

Verified: `pnpm lint:boundaries` green; frontend unit suite green (1937); `test/integration/sitemap-parity.test.js` green.